### PR TITLE
Repulsive Curves

### DIFF
--- a/RepulsiveCurvesExamples.hs
+++ b/RepulsiveCurvesExamples.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE GHC2024 #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LexicalNegation #-}
+{-# LANGUAGE OrPatterns #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RequiredTypeArguments #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module RepulsiveCurvesExamples (main) where
+
+import Control.Monad
+import Data.Functor
+import Data.List
+import Data.List.NonEmpty qualified as NE
+import Data.Vector qualified as V
+import Diagrams.CubicSpline (cubicSpline)
+import Diagrams.Located (Located)
+import Diagrams.Parametric (atParam)
+import Diagrams.Trail (Trail)
+import Linear hiding (outer)
+import Linear.Affine (Point (P), unP)
+import System.Environment
+import System.Exit (exitFailure)
+import System.Random.Stateful
+import Util.RepulsiveCurves
+import Vis qualified
+
+trefoilKnot :: Int -> Graph V3
+trefoilKnot numPoints = graphFromPath True [V3 (x i) (y i) (z i) | i <- [0 .. numPoints - 1]]
+  where
+    t i = 2 * pi * fromIntegral i / fromIntegral numPoints
+    x i = sin (t i) + 2 * sin (2 * t i)
+    y i = cos (t i) - 2 * cos (2 * t i)
+    z i = -(sin (3 * t i))
+
+figureEightKnot :: Int -> Graph V3
+figureEightKnot numPoints = graphFromPath True [V3 (x i) (y i) (z i) | i <- [0 .. numPoints - 1]]
+  where
+    t i = 2 * pi * fromIntegral i / fromIntegral numPoints
+    x i = (2 + cos (2 * t i)) * cos (3 * t i)
+    y i = (2 + cos (2 * t i)) * sin (3 * t i)
+    z i = sin (4 * t i)
+
+starCurve :: Double -> Graph V2
+starCurve r = graphFromPath True . concat $ zipWith (\a b -> [a, b]) inner outer
+  where
+    inner = [V2 ((r * 0.58) * cos t) ((r * 0.58) * sin t) | t <- [0 .. 5] <&> \t -> t * 2 * pi / 6]
+    outer = [V2 (r * cos t) (r * sin t) | t <- map (\t -> t * 2 * pi / 6 + pi / 6) [0 .. 5]]
+
+helixGraph :: [Vis.Color] -> Graph V3
+helixGraph helices =
+    graphFromPaths $
+        zip helices [0 ..] <&> \(c, i) ->
+            (c,False,)
+                [ V3 (radius * cos t') (radius * sin t') (t * turnHeight)
+                | t <- [0 .. numEdgesPerHelix] <&> ((* turns) . (/ numEdgesPerHelix))
+                , let t' = t * 2 * pi + (i / numHelices * 2 * pi)
+                ]
+  where
+    numEdgesPerTurn = 6
+    radius = 3
+    turnHeight = 2
+    turns = 3
+    numEdgesPerHelix = turns * numEdgesPerTurn
+    numHelices = genericLength helices
+
+interleavedCurves :: Int -> [Vis.Color] -> Graph V3
+interleavedCurves numPoints curves =
+    graphFromPaths $ zip curves [0 ..] <&> \(c, i) -> (c, False, curve (2 * i * pi / n))
+  where
+    n = genericLength curves
+    cylinderRadius = 1
+    cylinderHeight = 4
+    centerRadius = 0.1
+    circlePoint theta radius = V3 (radius * cos theta) (radius * sin theta)
+    curve startAngle = smooth numPoints [start, middle, end]
+      where
+        start = circlePoint startAngle cylinderRadius (cylinderHeight / 2)
+        middle = circlePoint (startAngle + 2 * pi / 3) centerRadius 0
+        end = circlePoint (startAngle + 4 * pi / 3) cylinderRadius -(cylinderHeight / 2)
+    smooth res points = [0 .. res - 1] <&> \i -> unP $ trail `atParam` (fromIntegral i / fromIntegral (res - 1))
+      where
+        trail = cubicSpline @(Located (Trail _ _)) False $ P <$> points
+
+noisyCurve :: StdGen -> Double -> Graph V3 -> Graph V3
+noisyCurve gen amplitude Graph{..} =
+    Graph{vertices = V.zipWith (+) vertices (V.fromList noiseVecs), edges}
+  where
+    noiseVecs = runStateGen_ gen \StateGenM ->
+        replicateM (V.length vertices) $
+            V3
+                <$> uniformRM (-amplitude, amplitude) StateGenM
+                <*> uniformRM (-amplitude, amplitude) StateGenM
+                <*> uniformRM (-amplitude, amplitude) StateGenM
+
+main :: IO ()
+main =
+    getArgs >>= \case
+        []; _ : _ : _ -> putStrLn "expected single arg" >> exitFailure
+        [n] -> case n of
+            "1" -> run3 $ noisyCurve gen 0.95 $ trefoilKnot 24
+            "2" -> run3 $ noisyCurve gen 0.95 $ trefoilKnot 50 -- slow!
+            "3" -> run3 $ noisyCurve gen 0.8 $ figureEightKnot 24
+            "4" -> run2 $ starCurve 3
+            -- "5" -> run2 collatz
+            "6" -> run3 $ helixGraph [Vis.azure, Vis.orange, Vis.white] -- slow!
+            "7" -> run3 $ interleavedCurves 10 [Vis.azure, Vis.orange, Vis.white]
+            _ -> putStrLn "unknown example number" >> exitFailure
+  where
+    (run2, run3) =
+        ( run \(V2 x y) -> V3 x y 0
+        , run id
+        )
+      where
+        run :: (RCVector v) => (v Double -> V3 Double) -> Graph v -> IO ()
+        run emb g = do
+            let initialEnergy = totalCurveEnergy enParams g
+                steps = optimizeCurve enParams optParams g
+                finalEnergy = totalCurveEnergy enParams $ NE.last steps
+            -- visCurves visDuration (NE.singleton knot) >> exitSuccess -- just show the first frame, and don't compute anything
+            putStrLn $ "Initial energy: " <> show initialEnergy
+            putStrLn $ "Final energy: " <> show finalEnergy
+            putStrLn $ "Energy reduction: " <> show (100 * (1 - finalEnergy / initialEnergy)) <> "%"
+            putStrLn $ "Steps taken: " <> show (NE.length steps)
+            visCurves visDuration $ hfmapGraph emb <$> steps
+    gen = mkStdGen 42
+    enParams =
+        EnergyParams
+            { alpha = 2.0
+            , beta = 4.5
+            , epsilon = 1e-6
+            , finiteDiffStep = 1e-3
+            , minGradientNorm = 1e-8
+            , stepSize = 1e-3
+            , maxAdaptiveStep = 1e-1
+            }
+    optParams =
+        OptimizationParams
+            { maxIterations = 200
+            , tolerance = 1e-3
+            , preserveLength = Nothing
+            }
+    visDuration = 3

--- a/Util/RepulsiveCurves.hs
+++ b/Util/RepulsiveCurves.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE GHC2024 #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LexicalNegation #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Util.RepulsiveCurves where
+
+import Data.Composition ((.:))
+import Data.Fixed (mod')
+import Data.Functor hiding (unzip)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NE
+import Data.Monoid.Extra
+import Data.Time
+import Data.Tuple.Extra
+import Data.Vector (Vector)
+import Data.Vector qualified as V
+import Data.Vector.Mutable qualified as VM
+import Linear
+import Vis
+
+-- TODO we should probably represent things differently given that only positions ever change
+-- e.g. use an abstract graph (with annotations for colour and more) and then a map from vertex ID to coordinate
+-- at that point, I really should probably just use `fgl`
+data Graph v = Graph
+    { vertices :: Vector (v Double)
+    , edges :: Vector ((Int, Int), Color)
+    }
+deriving instance (RCVector v) => Show (Graph v)
+hfmapGraph :: (f Double -> g Double) -> Graph f -> Graph g
+hfmapGraph f g = g{vertices = f <$> g.vertices}
+graphFromPath :: (RCVector v) => Bool -> [v Double] -> Graph v
+graphFromPath = graphFromPaths . pure .: (azure,,)
+graphFromPaths :: (RCVector v) => [(Color, Bool, [v Double])] -> Graph v
+graphFromPaths =
+    uncurry Graph
+        . (\(a, b, _) -> (V.fromList a, V.fromList b))
+        . foldl
+            ( flip \(color, closed, vertices) (vss, ess, acc) ->
+                let
+                    n = length vertices
+                    edges = map (,color) $ zip [0 .. n - 2] [1 .. n - 1] <> mwhen closed [(n - 1, 0)]
+                 in
+                    (vss <> vertices, ess <> map (first $ both (+ acc)) edges, acc + n)
+            )
+            ([], [], 0)
+
+data EnergyParams = EnergyParams
+    { alpha :: Double
+    , beta :: Double
+    , epsilon :: Double
+    , -- TODO these last 4 are quite closely related - there should be a better way to specify them
+      finiteDiffStep :: Double
+    , minGradientNorm :: Double
+    , stepSize :: Double
+    , maxAdaptiveStep :: Double
+    }
+    deriving (Show)
+
+data OptimizationParams = OptimizationParams
+    { maxIterations :: Int
+    , tolerance :: Double
+    , preserveLength :: Maybe Double -- TODO hmm, if `Just` this should really be computed from initial curve
+    }
+    deriving (Show)
+
+totalCurveEnergy :: (RCVector v) => EnergyParams -> Graph v -> Double
+totalCurveEnergy EnergyParams{..} Graph{..} =
+    sum [edgeEdgeEnergy (edgeVertices e1) (edgeVertices e2) | e1 <- [0 .. n - 1], e2 <- [e1 + 2 .. n - 1]]
+  where
+    -- TODO we always seem to be folding and iterating through vectors - we could probably just use lists...
+    n = V.length edges
+    edgeVertices e = both (vertices V.!) $ fst $ edges V.! e
+    -- TODO after questioning Claude about how closely we really copy the advanced techniques in the paper,
+    -- it suggested this alternative for this function
+    -- I haven't tested it much, but it's way slower, and I haven't seen any improvements yet to make up for that
+    -- besides, it's still a long way from all the double integrals and stuff we should be doing
+    -- let alone the whole constraint system
+    -- edgeEdgeEnergy e1 e2 = integralSum * norm tan1 * norm tan2
+    --   where
+    --     tan1 = uncurry (-) e1
+    --     tan2 = uncurry (-) e2
+
+    --     -- Parameterize edges as γ₁(s) and γ₂(t) for s,t ∈ [0,1]
+    --     gamma1 s = uncurry (lerp s) e1
+    --     gamma2 t = uncurry (lerp t) e2
+
+    --     -- Numerical integration over [0,1] × [0,1]
+    --     numSamples = 10 :: Int -- Should be configurable
+    --     ds = 1.0 / fromIntegral numSamples
+    --     dt = 1.0 / fromIntegral numSamples
+
+    --     integralSum =
+    --         sum
+    --             [ tangentPointKernel (gamma1 s) (gamma2 t) tan1 * ds * dt
+    --             | s <- [ds / 2, ds + ds / 2 .. 1 - ds / 2] -- Midpoint rule
+    --             , t <- [dt / 2, dt + dt / 2 .. 1 - dt / 2]
+    --             ]
+    edgeEdgeEnergy (i1, j1) (i2, j2) = avgKernel * norm tan1 * norm tan2
+      where
+        tan1 = j1 - i1
+        tan2 = j2 - i2
+        kernelVals =
+            [ tangentPointKernel p q tan1
+            | p <- [i1, 0.5 *^ (i1 + j1), j1]
+            , q <- [i2, 0.5 *^ (i2 + j2), j2]
+            ]
+        avgKernel = sum kernelVals / fromIntegral (length kernelVals)
+    tangentPointKernel p q t =
+        if diffNorm < epsilon
+            then 0
+            else (crossNorm' ** alpha) / (diffNorm ** beta)
+      where
+        diff = p - q
+        diffNorm = norm diff
+        crossNorm' = crossNorm t diff
+
+gradientDescentStep :: forall v. (RCVector v) => EnergyParams -> Graph v -> Graph v
+gradientDescentStep params curve = curve{vertices = V.zipWith (\v g -> v - (adaptiveStep *^ g)) curve.vertices gradient}
+  where
+    gradient = V.generate (V.length curve.vertices) vertexGradient
+    gradNorm = V.sum $ norm <$> gradient
+    adaptiveStep =
+        if gradNorm > params.minGradientNorm
+            then min params.stepSize (params.maxAdaptiveStep / gradNorm) -- prevent huge steps
+            else params.stepSize
+    vertexGradient vIndex = finiteDifference . (^* h) <$> identity
+      where
+        h = params.finiteDiffStep
+        originalEnergy = totalCurveEnergy params curve
+        finiteDifference delta = (perturbedEnergy - originalEnergy) / h
+          where
+            perturbedCurve = curve{vertices = V.modify (\m -> VM.modify m (+ delta) vIndex) curve.vertices}
+            perturbedEnergy = totalCurveEnergy params perturbedCurve
+
+preserveLengthConstraint :: (RCVector v) => Double -> Graph v -> Graph v
+preserveLengthConstraint targetLength curve = curve{vertices = newVertices}
+  where
+    currentLength = sum $ uncurry distance <$> edges
+    edges = both (curve.vertices V.!) . fst <$> curve.edges
+    scaleFactor = sqrt $ targetLength / currentLength
+    centroid = (1 / fromIntegral (V.length curve.vertices)) *^ V.foldl' (+) 0 curve.vertices
+    newVertices = curve.vertices <&> \v -> centroid + (scaleFactor *^ (v - centroid)) -- scale relative to centroid
+
+optimizeCurve :: (RCVector v) => EnergyParams -> OptimizationParams -> Graph v -> NonEmpty (Graph v)
+optimizeCurve energyParams OptimizationParams{..} initialCurve =
+    go 0 initialCurve Nothing
+  where
+    go iter curve prevEnergy =
+        -- TODO this should be some sort of fold
+        -- `curve` is always prepended, and `prevEnergy` is `Nothing` iff this is the first call
+        curve
+            :| if iter >= maxIterations
+                || energy == 0
+                || maybe False (\pe -> abs (energy - pe) / abs pe < tolerance) prevEnergy
+                then []
+                else NE.toList $ go (iter + 1) curve' (Just energy)
+      where
+        curve' = maybe id preserveLengthConstraint preserveLength $ gradientDescentStep energyParams curve
+        energy = totalCurveEnergy energyParams curve
+
+-- TODO is there a better abstraction here?
+-- `crossNorm @V2` can be defined as `\v1 v2 -> let emb (V2 x y) = V3 x y 0 in norm $ emb v1 \`cross\` emb v2`,
+-- so we could just have an `Embeddable` class, but that feels like it gives us too much power,
+-- whereas we actually do do all the computation in `V2` for the planar case rather than embedding,
+-- plus this implementation is probably more performant
+class
+    ( Metric v
+    , Applicative v
+    , Traversable v
+    , -- , forall a. (Num a) => Num (v a)
+      -- , forall a. (Show a) => Show (v a)
+      Num (v Double)
+    , Show (v Double)
+    ) =>
+    RCVector v
+    where
+    crossNorm :: (Floating a) => v a -> v a -> a
+instance RCVector V2 where
+    crossNorm v1 v2 = abs $ v1 `crossZ` v2
+instance RCVector V3 where
+    crossNorm v1 v2 = norm $ v1 `cross` v2
+
+visCurves :: NominalDiffTime -> NonEmpty (Graph V3) -> IO ()
+visCurves duration vs = animate defaultOpts \t ->
+    let t' = t `mod'` d
+        d = realToFrac duration
+        vs' = V.fromList $ NE.toList vs
+        l = V.length vs'
+        -- t'' = min (l - 1) $ floor $ t * fromIntegral l / d -- remains on last frame
+        t'' = floor $ t' * fromIntegral l / d
+     in VisObjects
+            [ let v = vs' V.! t''
+               in VisObjects $
+                    V.toList v.edges
+                        <&> \((v1, v2), c) -> Line Nothing ((v.vertices V.!) <$> [v1, v2]) c
+            , Text2d (show (l, t'', t')) (0, 0) Helvetica18 red
+            -- , Text3d "origin" 0 Helvetica18 red
+            ]


### PR DESCRIPTION
Inspired by [Keenan Crane's work](https://www.cs.cmu.edu/~kmcrane/Projects/RepulsiveCurves/index.html), but taking a much simpler approach.

This code works pretty well for some examples considering that it doesn't have any of the paper's sophisticated maths. It's only really good for separation though, not packing, and particularly not with the sparse 2D trees which originally prompted me to look in to this.

The coolest thing here is that we abstract neatly over the 2D and 3D cases.

Note also that this is partially vibe-coded, and while I've cleaned up and removed most magic numbers and inlined and simplified a lot of things, there are still some lines I haven't really reviewed. For example, I'm not quite sure why we have `e2 <- [e1 + 2 .. n - 1]` instead of `e2 <- [e1 + 1 .. n - 1]`.

I'd love to see this properly implemented as a library, since the demos are very impressive, and the only implementation is an abandoned research-quality C++ playground. Unfortunately I probably don't have the time nor the right sort of mathematical background.
