### PR TITLE
Allow arbitrary-precision arithmetic for Mandelbrot set

### DIFF
--- a/Mandelbrot.hs
+++ b/Mandelbrot.hs
@@ -30,9 +30,13 @@ power = 2
     l = 1.2
     baseColour = hsv 218 0.68 1
 
-divergenceIterations c = findIndex ((>= (bound ^ 2)) . magnitudeSquared) . take maxIterations $ iterate (\z -> z ** power + c) 0
+divergenceIterations c = findIndex ((>= (bound ^ 2)) . magnitudeSquared) . take maxIterations $ iterate (\z -> (z ^! power) +! c) (0 :+ 0)
   where
     magnitudeSquared (x :+ y) = x * x + y * y
+    -- avoids requiring `RealFloat` for inner type
+    (x :+ y) +! (x' :+ y') = (x + x') :+ (y + y')
+    (x :+ y) *! (x' :+ y') = (x * x' - y * y') :+ (x * y' + y * x')
+    c' ^! n = foldr (*!) (1 :+ 0) $ replicate n c'
 
 main =
     writePng "mandelbrot.png" $


### PR DESCRIPTION
The hope was that, inspired by [this post](https://www.reddit.com/r/fractals/comments/pxapx9/a_cool_spot_i_found_in_the_mandelbrot_set_using/), we could do something like:
```hs
centre = (-186118704117988690.6e-17, -000260597392929367.5e-17)
size = 3e-17
bound = 2 :: Fixed 10000000000000000000
```
But unfortunately this requires at least `maxIterations = 5000` in order to start bringing out the shapes (and possibly a lot more to reveal the internal copy of the Mandelbrot set itself), and even a 200x200 image takes 1m16s to generate on my iMac Pro. So it's not feasible without optimisations.
